### PR TITLE
Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,8 @@ module.exports = function getPlugin(S) {
           const handlerEntryPath = `./${handlerFileName}`;
 
           // override entry and output
-          webpackConfig.context = path.dirname(func.getFilePath());
+          webpackConfig.context = path.dirname(func.getFilePath())
+            .replace(/\//g, path.sep); // Ensure windows support
           if (Array.isArray(webpackConfig.entry)) {
             webpackConfig.entry.push(handlerEntryPath);
           } else {

--- a/lib/copyModules.js
+++ b/lib/copyModules.js
@@ -27,5 +27,7 @@ module.exports = function copyModules(projectPath, moduleNames, dest) {
 
   // Run 'npm install' on each module to get a full set of dependencies,
   // not just the directly copied ones.
-  return exec('npm', args, opts);
+  // Windows support credit:
+  // https://github.com/nodejs/node-v0.x-archive/issues/5841#issuecomment-249355832
+  return exec(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', args, opts);
 };


### PR DESCRIPTION
Those patches ensure that project lambdas pack without issues on Windows

1. On Windows Serverless v0.x `func.getFilePath()` returns paths with posix path separators, we need to convert them to have right one on Windows
2. On Windows`child_process.execFile` to refer to `npm` globally we need to use `npm.cmd`

Tested both on Windows (fixed) and *nix (things work as they worked)